### PR TITLE
Unbuffer reading the port etc.

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"time"
@@ -10,11 +9,10 @@ import (
 )
 
 type Connect struct {
-	portPath   string
-	baudRate   int
-	port       *term.Term
-	portReader *bufio.Reader
-	stateChan  chan error
+	portPath  string
+	baudRate  int
+	port      *term.Term
+	stateChan chan error
 }
 
 // NewConnection returns a pointer to a Connect instance
@@ -25,11 +23,9 @@ func NewConnection(portPath string, baudRate int) (*Connect, error) {
 		return nil, err
 	}
 	port.SetRaw()
-	portReader := bufio.NewReader(port)
 	stateChan := make(chan error)
 	return &Connect{portPath: portPath, baudRate: baudRate, port: port,
-		portReader: portReader,
-		stateChan:  stateChan}, nil
+		stateChan: stateChan}, nil
 }
 
 // Start initializes a read loop that attempts to reconnect
@@ -59,22 +55,22 @@ func (c *Connect) initialize() {
 			continue
 		}
 		c.port = port
-		c.portReader = bufio.NewReader(port)
 		c.stateChan <- nil
 		return
 	}
 }
 
 func (c *Connect) read() {
+	buf := make([]byte, 1)
 	for {
-		response, err := c.portReader.ReadBytes('\n')
+		n, err := io.ReadFull(c.port, buf)
 		// report the error
 		if err != nil && err != io.EOF {
 			c.stateChan <- err
 			return
 		}
-		if len(response) > 0 {
-			fmt.Print(string(response))
+		if n > 0 {
+			fmt.Print(string(buf))
 		}
 	}
 }

--- a/connect_test.go
+++ b/connect_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,7 @@ func TestNewConnection(t *testing.T) {
 	port1 := "/tmp/bifrostport1"
 	port2 := "/tmp/bifrostport2"
 	testInput := []byte("from Asgard...\n")
+	message1 := make([]byte, len(testInput))
 
 	_, err := NewConnection(port0, 115200)
 	require.Error(t, err)
@@ -24,7 +26,7 @@ func TestNewConnection(t *testing.T) {
 	require.NoError(t, err)
 
 	connect1.Write(testInput)
-	message1, err := connect2.portReader.ReadBytes('\n')
+	_, err = io.ReadFull(connect2.port, message1)
 	require.NoError(t, err)
 	assert.Equal(t, testInput, message1)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,15 @@ module github.com/ishuah/bifrost
 go 1.19
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 // indirect
 	github.com/micmonay/keybd_event v0.0.0-20190804163414-202c5b2c8150
 	github.com/pkg/term v0.0.0-20180423043932-cda20d4ac917
-	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.3.0
-	github.com/tarm/serial v0.0.0-20180114052751-eaafced92e96
 	gopkg.in/ini.v1 v1.62.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/smartystreets/goconvey v1.6.4 // indirect
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,10 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 h1:AYzjK/SHz6m6mg5iuFwkrAhCc14jvCpW9d6frC9iDPE=
-github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7/go.mod h1:iYGcTYIPUvEWhFo6aKUuLchs+AV4ssYdyuBbQJZGcBk=
 github.com/micmonay/keybd_event v0.0.0-20190804163414-202c5b2c8150 h1:PqImcOtccrVBlCsNbaJVenb+4EjpeOL3HPk4bCCQrCY=
 github.com/micmonay/keybd_event v0.0.0-20190804163414-202c5b2c8150/go.mod h1:QS2Kfz0PbPezFqMPEot+l/cK78/tHLZtZ7AbYUCRKsQ=
 github.com/pkg/term v0.0.0-20180423043932-cda20d4ac917 h1:BinR73QvQveJdQ8uYZK/8MOjLADpZbI2qs/2+5rnhzQ=
@@ -19,12 +18,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/tarm/serial v0.0.0-20180114052751-eaafced92e96 h1:pLss0TM/G46eE2p8NIRYIlB12vrPvWXiqDoCKA52wwQ=
-github.com/tarm/serial v0.0.0-20180114052751-eaafced92e96/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sys v0.0.0-20180202135801-37707fdb30a5 h1:MF92a0wJ3gzSUVBpjcwdrDr5+klMFRNEEu6Mev4n00I=
-golang.org/x/sys v0.0.0-20180202135801-37707fdb30a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func main() {
 			case Esc:
 				connect.Write([]byte{'\x1b'})
 			case CtrlBackslash:
-				fmt.Print("bye!")
+				fmt.Println("\nbye!")
 				return
 			case Tab:
 				connect.Write([]byte{'\x09'})


### PR DESCRIPTION
Hi, thanks for the nice tool!

I've found some things to improve for better bifrost, so I've made some commits here:

### 5fd6351 Run go mod tidy
- Go compiler asked me to do so because there were some packages like "xgo" that aren't in use anymore.

### e970ec5 Unbuffer reading the port for realtime interaction
- In the original code, `bufio` was used to buffer the line and read the RX line-by-line.
- Since [there is a buffer on the kernel side](https://github.com/pkg/term/blob/1a4a3b719465afccedae7788469c0b54a43417e0/term.go#L78-L81), we won't need additional buffering.
- Additionally, for an interactive session like connecting the UART on a Linux machine's serial tty, any output incl. echo back will be transmitted without newline. With buffering a line, I couldn't observe any output on display until I press Enter.
- I used `io.ReadFull` with a single byte buffer instead, so now bifrost can receive and display every single byte as soon as it's received.

### dd03a78 Farewell with a fresh line
- There should be `\n` around "bye!" so that I can take screenshots of the log intact, and the friendly farewell will be more visible to users :wink:

I hope these changes are ok for you! Thanks!